### PR TITLE
android: unset pluginChannel in onDetachedFromEngine()

### DIFF
--- a/unifiedpush_android/android/src/main/kotlin/org/unifiedpush/flutter/connector/Plugin.kt
+++ b/unifiedpush_android/android/src/main/kotlin/org/unifiedpush/flutter/connector/Plugin.kt
@@ -102,6 +102,7 @@ class Plugin : FlutterPlugin, MethodCallHandler {
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         Log.d(TAG, "onDetachedFromEngine")
         pluginChannel?.setMethodCallHandler(null)
+        pluginChannel = null
         mContext = null
     }
 


### PR DESCRIPTION
Closes: https://github.com/UnifiedPush/flutter-connector/issues/104