### PR TITLE
Don't explicitly call _onUnregistered in unregisterApp()

### DIFF
--- a/unifiedpush_android/lib/unifiedpush_android.dart
+++ b/unifiedpush_android/lib/unifiedpush_android.dart
@@ -47,7 +47,6 @@ class UnifiedPushAndroid extends UnifiedPushPlatform {
 
   @override
   Future<void> unregister(String instance) async {
-    _onUnregistered?.call(instance);
     await _channel.invokeMethod(pluginEventUnregister, [instance]);
   }
 


### PR DESCRIPTION
The distributor is supposed to invoke this callback when the instance has been successfully unregistered.