### PR TITLE
Revert "Don't explicitly call _onUnregistered in unregisterApp()"

### DIFF
--- a/unifiedpush_android/lib/unifiedpush_android.dart
+++ b/unifiedpush_android/lib/unifiedpush_android.dart
@@ -47,6 +47,7 @@ class UnifiedPushAndroid extends UnifiedPushPlatform {
 
   @override
   Future<void> unregister(String instance) async {
+    _onUnregistered?.call(instance);
     await _channel.invokeMethod(pluginEventUnregister, [instance]);
   }
 


### PR DESCRIPTION
Reverts UnifiedPush/flutter-connector#115

Ping @emersion 

---

I was a little too quick to accept PR #115, so I open this one to discuss a bit what is the best behavior.

On the android lib, the connector set a `onUnregistered` method in a broadcast listener in case the distributor unregister it.
And if the app sends an `unregister` request, the connector removes directly the connection token, so the `onUnregistered` after it is ignored.

On flutter, calling `unregister` does the same thing, but for ease of use it directly call `_onUnregistered`.

By removing the explicit call to `_onUnregistered`, the app need to write the unregistration logic after the `unregister` request. To illustrate:

With the explicit call to _onUnregistered:

```
[...]
void onUnregistered(String _instance) {
  myFunc(_instance);
}
[...]
UnifiedPush.unregister(instance);
// nothing
[...]
```
Without the explicit call:

```
[...]
void onUnregistered(String _instance) {
  myFunc(_instance);
}
[...]
UnifiedPush.unregister(instance);
myFunc(instance);
[...]
```

I think the flutter one is more efficient but it gives less liberty to the developers.

@emersion : What do you think of it ?

---

PS: Fortunately, the modification of this behavior seems to disturb only the example :)