### PR TITLE
android: ensure only one FlutterEngine gets created

### DIFF
--- a/unifiedpush_android/android/src/main/kotlin/org/unifiedpush/flutter/connector/UnifiedPushReceiver.kt
+++ b/unifiedpush_android/android/src/main/kotlin/org/unifiedpush/flutter/connector/UnifiedPushReceiver.kt
@@ -21,12 +21,19 @@ open class UnifiedPushReceiver : BroadcastReceiver() {
     private val handler = Handler()
     private var pluginChannel : MethodChannel? = null
 
+    companion object {
+        private var engine : FlutterEngine? = null
+    }
+
     open fun getEngine(context: Context): FlutterEngine? {
-        val engine = FlutterEngine(context)
-        engine.localizationPlugin.sendLocalesToFlutter(
+        if (engine != null) {
+            return engine;
+        }
+        engine = FlutterEngine(context)
+        engine!!.localizationPlugin.sendLocalesToFlutter(
             context.resources.configuration
         )
-        engine.dartExecutor.executeDartEntrypoint(
+        engine!!.dartExecutor.executeDartEntrypoint(
             DartExecutor.DartEntrypoint.createDefault()
         )
         return engine


### PR DESCRIPTION
When handling multiple messages in a row, UnifiedPushReceiver could create multiple FlutterEngines: onReceive() is called, but Plugin.pluginChannel stays null before Plugin.onAttachedToEngine() is invoked.

Ensure we create only a single FlutterEngine per UnifiedPushReceiver.