### PR TITLE
android: drop fixed jvmToolchain

### DIFF
--- a/unifiedpush_android/android/build.gradle
+++ b/unifiedpush_android/android/build.gradle
@@ -30,13 +30,17 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
-
-kotlin {
-    jvmToolchain(8)
-}
-
 android {
     compileSdk 34
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
This forces a specific JVM toolchain version. Fixes the following error:

    Could not determine the dependencies of task ':unifiedpush_android:compileReleaseKotlin'.
    > Cannot find a Java installation on your machine matching this tasks requirements: {languageVersion=8, vendor=any, implementation=vendor-specific} for LINUX on x86_64.
       > No locally installed toolchains match and toolchain download repositories have not been configured.